### PR TITLE
Fixes enemy death

### DIFF
--- a/Assets/Scenes/Overworld.unity
+++ b/Assets/Scenes/Overworld.unity
@@ -9048,6 +9048,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 878947365}
+  - component: {fileID: 878947366}
   m_Layer: 0
   m_Name: Snakes
   m_TagString: Untagged
@@ -9081,6 +9082,21 @@ Transform:
   - {fileID: 415653490}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &878947366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 878947364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e32dc37d2f8b943c9b48d44aadabed45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyLayer:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!1001 &881909233
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -52,6 +52,7 @@ public class EnemyController : MonoBehaviour
         health -= damage;
         if (health <= 0f)
         {
+            Debug.Log("Enemy dead");
             currentState = EnemyState.Dead;
             animator.SetBool(AnimatorParams.IsDead, true);
             // TODO: BUG - don't destroy game object before attempting to play hit
@@ -76,6 +77,8 @@ public class EnemyController : MonoBehaviour
 
     private IEnumerator StartAttack(GameObject other)
     {
+        // Exit early if enemy has died
+        if (currentState == EnemyState.Dead) { yield break; }
         // Enter agro state and handle facing direction if necessary
         Rigidbody2D targetRigidbody = other.GetComponent<Rigidbody2D>();
         Debug.Log("Enemy aggro");
@@ -88,6 +91,8 @@ public class EnemyController : MonoBehaviour
         yield return new WaitForSeconds(AgroTimeBeforeAttack);
 
         // Start attack
+        // Exit early if enemy has died
+        if (currentState == EnemyState.Dead) { yield break; }
         Debug.Log("Enemy attack");
         currentState = EnemyState.Attacking;
         // Calculate the direction towards the target again, in case the player has moved
@@ -112,12 +117,16 @@ public class EnemyController : MonoBehaviour
 
     private IEnumerator AttackCooldown()
     {
+        // Exit early if enemy has died
+        if (currentState == EnemyState.Dead) { yield break; }
         Debug.Log("Enemy cooldown");
         currentState = EnemyState.AttackCooldown;
         // Reset target direction
         targetDirection = Vector2.zero;
         animator.SetBool(AnimatorParams.IsMoving, false);
         yield return new WaitForSeconds(AttackCooldownTime);
+        // Exit early if enemy has died
+        if (currentState == EnemyState.Dead) { yield break; }
         Debug.Log("Enemy default");
         currentState = EnemyState.Default;
         // Check if player is still in agro range. If so, attack again


### PR DESCRIPTION
Puts CombatEncounterController on Snakes gameobject container. Breaks enemy movement coroutines early if snake has died.