### PR TITLE
Adds interaction y offset facing down field to player

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -214,6 +214,7 @@ MonoBehaviour:
   interactionZoneSize: {x: 2, y: 2}
   interactionOffset: 0.5
   InteractionYOffset: 2.01
+  InteractionYOffsetFacingDown: 1.8
 --- !u!114 &2947611010104209421
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -255,6 +256,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   AudioData: {fileID: 11400000, guid: 2e2e86869796548869e37110561c8381, type: 2}
+  currentTerrain: 
 --- !u!114 &8454525523054177503
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -194,7 +194,8 @@ public class PlayerController : MonoBehaviour
 
     private Dialogue checkForDialogueCollision()
     {
-        Vector3 interactPos = transform.position + new Vector3(0, InteractionYOffset, 0); // Player's center position + y offset
+        float interactionYOffset = FacingDirection == FacingDirection.Down ? InteractionYOffsetFacingDown : InteractionYOffset;
+        Vector3 interactPos = transform.position + new Vector3(0, interactionYOffset, 0); // Player's center position + y offset
 
         // Define the size of the rectangle (adjust dynamically based on FacingDirection)
         Vector2 interactionZoneSize;
@@ -271,7 +272,8 @@ public class PlayerController : MonoBehaviour
     //Interaction zone adjustable in Inspector
     [SerializeField] private Vector2 interactionZoneSize = new Vector2(1f, 0.5f); // Width and Height
     [SerializeField] private float interactionOffset = 0.5f; // Distance from the player's center
-    [SerializeField] public float InteractionYOffset; // Add vertical offset from the player's center
+    [SerializeField] public float InteractionYOffset; // Add vertical offset from the player's center while facing up
+    [SerializeField] public float InteractionYOffsetFacingDown; // Add vertical offset from the player's center while facing down
 
     void Update()
     {


### PR DESCRIPTION
New field determines offset for sign detection when facing down, and sets it slightly lower, so that the player can't read signs behind him while facing down.