### PR TITLE
Implement player health and take damage

### DIFF
--- a/Assets/Scenes/Overworld.unity
+++ b/Assets/Scenes/Overworld.unity
@@ -927,7 +927,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1223886786689972409, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 4.14
       objectReference: {fileID: 0}
     - target: {fileID: 1530922684326905548, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_LocalScale.x
@@ -1035,7 +1034,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8980723282171336176, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.y
-      value: 4.14
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -6556,6 +6554,10 @@ PrefabInstance:
     - target: {fileID: 8443585188686732594, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454525523054177503, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
+      propertyPath: colorChangeDuration
+      value: 0.248
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/Overworld.unity
+++ b/Assets/Scenes/Overworld.unity
@@ -927,6 +927,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1223886786689972409, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1530922684326905548, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_LocalScale.x
@@ -1034,6 +1035,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8980723282171336176, guid: 00a4fbb80e34a5f46904fde20117260a, type: 3}
       propertyPath: m_SpriteTilingProperty.oldSize.y
+      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -6550,6 +6552,10 @@ PrefabInstance:
     - target: {fileID: 5553036053896267798, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5957394632817136815, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
+      propertyPath: Health
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8443585188686732594, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
       propertyPath: m_Enabled

--- a/Assets/Scripts/EnemyController.cs
+++ b/Assets/Scripts/EnemyController.cs
@@ -65,7 +65,7 @@ public class EnemyController : MonoBehaviour
         {
             PlayerController playerController = collision.gameObject.GetComponent<PlayerController>();
             // TODO: improve this so that player can only take damage once per attack
-            playerController.TakeDamage();
+            StartCoroutine(playerController.TakeDamage());
         }
     }
 

--- a/Assets/Scripts/PlayerAttack.cs
+++ b/Assets/Scripts/PlayerAttack.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class PlayerAttack : MonoBehaviour
@@ -9,10 +11,19 @@ public class PlayerAttack : MonoBehaviour
     public float attackCoolDownTime;
 
     private WeaponController weaponController;
+    private PlayerController playerController;
+    // Access Sprite Renderer, default color and time to have character briefly flash red when damaged
+    private SpriteRenderer spriteRenderer;
+    private Color defaultSpriteColor;
+    [Range(0f, 1f)]
+    public float colorChangeDuration;
 
     void Awake()
     {
         weaponController = Weapon.GetComponent<WeaponController>();
+        playerController = gameObject.GetComponent<PlayerController>();
+        spriteRenderer = GetComponent<SpriteRenderer>();
+        defaultSpriteColor = spriteRenderer.color;
     }
 
     private IEnumerator AttackCooldown()
@@ -29,9 +40,52 @@ public class PlayerAttack : MonoBehaviour
         StartCoroutine(AttackCooldown());
     }
 
+    public void DamageColorChange()
+    {
+        StartCoroutine(DamageColorChangeRoutine());
+    }
+
+    private IEnumerator DamageColorChangeRoutine()
+    {
+        float elapsedTime = 0f;
+
+        while (elapsedTime < colorChangeDuration)
+        {
+            // Calculate t based on elapsed time
+            float t = elapsedTime / colorChangeDuration;
+
+            // Lerp between defaultSpriteColor and Color.red
+            spriteRenderer.color = Color.Lerp(defaultSpriteColor, Color.red, t);
+
+            // Increment elapsed time
+            elapsedTime += Time.deltaTime;
+            yield return null; // Wait for the next frame
+        }
+        
+        // Reset to default color
+        spriteRenderer.color = defaultSpriteColor;
+    }
+
     public void TakeDamage()
     {
-        // TODO: implement "stunned" state
-        Debug.Log("Ouch!");
+        playerController.Health -= 1;
+
+        if (playerController.Health > 0)
+        {
+            // TODO: implement "stunned" state
+            PlayerController.CurrentState = PlayerState.Stunned;
+            DamageColorChange();
+            StartCoroutine(AttackCooldown());
+            Debug.Log("Ouch!");
+            PlayerController.CurrentState = PlayerState.Default;
+            Debug.Log($"Player health: {playerController.Health}"); 
+        }
+        else if (playerController.Health <= 0)
+        {
+            PlayerController.CurrentState = PlayerState.Dead;
+            spriteRenderer.enabled = !spriteRenderer.enabled;
+            Debug.Log("Dead!");
+        }
     }
+
 }

--- a/Assets/Scripts/PlayerAttack.cs
+++ b/Assets/Scripts/PlayerAttack.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using Unity.VisualScripting;
 using UnityEngine;
 
 public class PlayerAttack : MonoBehaviour
@@ -11,7 +10,6 @@ public class PlayerAttack : MonoBehaviour
     public float attackCoolDownTime;
 
     private WeaponController weaponController;
-    private PlayerController playerController;
     // Access Sprite Renderer, default color and time to have character briefly flash red when damaged
     private SpriteRenderer spriteRenderer;
     private Color defaultSpriteColor;
@@ -21,12 +19,11 @@ public class PlayerAttack : MonoBehaviour
     void Awake()
     {
         weaponController = Weapon.GetComponent<WeaponController>();
-        playerController = gameObject.GetComponent<PlayerController>();
         spriteRenderer = GetComponent<SpriteRenderer>();
         defaultSpriteColor = spriteRenderer.color;
     }
 
-    private IEnumerator AttackCooldown()
+    public IEnumerator AttackCooldown()
     {
         CanAttack = false;
         yield return new WaitForSeconds(attackCoolDownTime);
@@ -40,12 +37,7 @@ public class PlayerAttack : MonoBehaviour
         StartCoroutine(AttackCooldown());
     }
 
-    public void DamageColorChange()
-    {
-        StartCoroutine(DamageColorChangeRoutine());
-    }
-
-    private IEnumerator DamageColorChangeRoutine()
+    public IEnumerator DamageColorChangeRoutine()
     {
         float elapsedTime = 0f;
 
@@ -64,28 +56,6 @@ public class PlayerAttack : MonoBehaviour
         
         // Reset to default color
         spriteRenderer.color = defaultSpriteColor;
-    }
-
-    public void TakeDamage()
-    {
-        playerController.Health -= 1;
-
-        if (playerController.Health > 0)
-        {
-            // TODO: implement "stunned" state
-            PlayerController.CurrentState = PlayerState.Stunned;
-            DamageColorChange();
-            StartCoroutine(AttackCooldown());
-            Debug.Log("Ouch!");
-            PlayerController.CurrentState = PlayerState.Default;
-            Debug.Log($"Player health: {playerController.Health}"); 
-        }
-        else if (playerController.Health <= 0)
-        {
-            PlayerController.CurrentState = PlayerState.Dead;
-            spriteRenderer.enabled = !spriteRenderer.enabled;
-            Debug.Log("Dead!");
-        }
     }
 
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -177,10 +177,27 @@ public class PlayerController : MonoBehaviour
         Gizmos.DrawWireSphere(transform.position, 5.0f); // Match the interaction radius
     }
 
-    public void TakeDamage()
+    public IEnumerator TakeDamage()
     {
-        playerAttack.TakeDamage();
-        playerAudio.PlayHit();
+        Health -= 1;
+
+        if (CurrentState == PlayerState.Default)
+        {
+            // TODO: implement "stunned" state
+            CurrentState = PlayerState.Stunned;
+            StartCoroutine(playerAttack.DamageColorChangeRoutine());
+            playerAudio.PlayHit();
+            yield return StartCoroutine(playerAttack.AttackCooldown());
+            Debug.Log("Ouch!");
+            CurrentState = PlayerState.Default;
+            Debug.Log($"Player health: {Health}"); 
+        }
+        // TODO: Implement Player Death
+        // else if (Health <= 0)
+        // {
+        //     // PlayerController.CurrentState = PlayerState.Dead;
+        //     Debug.Log("Dead!");
+        // }
     }
 
     public void OnAttackFinished()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -8,6 +8,8 @@ public enum PlayerState {
     Dialogue,
     Instrument,
     InstrumentMelody,
+    Stunned,
+    Dead
 }
 
 public enum FacingDirection {
@@ -40,6 +42,7 @@ public class PlayerController : MonoBehaviour
     public LayerMask DialogueLayer;
     public LayerMask PushableLayer;
 
+    public float Health;
     private PlayerAnimation playerAnimation;
     private PlayerAttack playerAttack;
     private PlayerAudio playerAudio;


### PR DESCRIPTION
Set a default health of 5 for the player (public variable set in editor). all enemies do 1 damage when attacking.
implemented a coroutine to have player flash red when damaged. When player's health is <= 0, they are dead and the sprite disappears (lol). added two more player states (stunned and dead) but they don't do anything yet. when in either of the above states player can't move