### PR TITLE
Player death

### DIFF
--- a/Assets/Prefabs/Checkpoint.prefab
+++ b/Assets/Prefabs/Checkpoint.prefab
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5227129890556966568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3595800479073566665}
+  - component: {fileID: -7518652477574915154}
+  - component: {fileID: 2614253940271093973}
+  m_Layer: 0
+  m_Name: Checkpoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3595800479073566665
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5227129890556966568}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-7518652477574915154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5227129890556966568}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 385f616da086b4e6d8b0d9313cd6262d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PlayerLayer:
+    serializedVersion: 2
+    m_Bits: 8
+--- !u!61 &2614253940271093973
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5227129890556966568}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 2, y: 0.5}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Checkpoint.prefab.meta
+++ b/Assets/Prefabs/Checkpoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ddffae83eae0141dcbd592705722d32a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -158,7 +158,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0.47}
+  m_Offset: {x: 0, y: 0.3189075}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0}
@@ -168,7 +168,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.9, y: 0.51}
+  m_Size: {x: 0.9, y: 0.6193075}
   m_EdgeRadius: 0
 --- !u!95 &4009678767995552547
 Animator:
@@ -211,6 +211,7 @@ MonoBehaviour:
   PushableLayer:
     serializedVersion: 2
     m_Bits: 1024
+  Health: 5
   interactionZoneSize: {x: 2, y: 2}
   interactionOffset: 0.5
   InteractionYOffset: 2.01
@@ -271,6 +272,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Weapon: {fileID: 2299894830920113254}
   attackCoolDownTime: 0.5
+  colorChangeDuration: 0.248
 --- !u!114 &8443585188686732594
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -213,6 +213,7 @@ MonoBehaviour:
     m_Bits: 1024
   MaxHealth: 5
   Health: 5
+  LastCheckpoint: {fileID: 0}
   interactionZoneSize: {x: 2, y: 2}
   interactionOffset: 0.5
   InteractionYOffset: 2.01

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -211,6 +211,7 @@ MonoBehaviour:
   PushableLayer:
     serializedVersion: 2
     m_Bits: 1024
+  MaxHealth: 5
   Health: 5
   interactionZoneSize: {x: 2, y: 2}
   interactionOffset: 0.5

--- a/Assets/Scenes/Overworld.unity
+++ b/Assets/Scenes/Overworld.unity
@@ -2797,6 +2797,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6839393333599276937, guid: eb3351900948d4d9da995026d32a65a1, type: 3}
   m_PrefabInstance: {fileID: 273195216}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &274229738
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2040737504}
+    m_Modifications:
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.475
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 8.012813
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 24.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5227129890556966568, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_Name
+      value: Church Checkpoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+--- !u!4 &274229739 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+  m_PrefabInstance: {fileID: 274229738}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &275535631
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2866,6 +2936,76 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9eebe71b786cc4bdcb7407d00d774a86, type: 3}
+--- !u!1001 &277558613
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2040737504}
+    m_Modifications:
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.275
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 9.529687
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 46.63
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5227129890556966568, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_Name
+      value: Beach Checkpoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+--- !u!4 &277558614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+  m_PrefabInstance: {fileID: 277558613}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &279444622
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6160,6 +6300,77 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4599908749039350432, guid: 9eebe71b786cc4bdcb7407d00d774a86, type: 3}
   m_PrefabInstance: {fileID: 347721613}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &593684683
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2040737504}
+    m_Modifications:
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.9125
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 19.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5227129890556966568, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+      propertyPath: m_Name
+      value: Dungeon Entrance Checkpoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+--- !u!4 &593684684 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3595800479073566665, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+  m_PrefabInstance: {fileID: 593684683}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &593684685 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5227129890556966568, guid: ddffae83eae0141dcbd592705722d32a, type: 3}
+  m_PrefabInstance: {fileID: 593684683}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &594666643
 PrefabInstance:
@@ -22225,6 +22436,40 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4599908749039350432, guid: 9eebe71b786cc4bdcb7407d00d774a86, type: 3}
   m_PrefabInstance: {fileID: 2039705936}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2040737503
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2040737504}
+  m_Layer: 0
+  m_Name: Checkpoints
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2040737504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2040737503}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.4290326, y: 17.740482, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 593684684}
+  - {fileID: 274229739}
+  - {fileID: 277558614}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &2041834859 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4599908749039350432, guid: 9eebe71b786cc4bdcb7407d00d774a86, type: 3}
@@ -23747,11 +23992,16 @@ PrefabInstance:
       value: -180
       objectReference: {fileID: 0}
     - target: {fileID: 9213398412280628274, guid: ee35a22c9c046446c9f2e4b25053cb69, type: 3}
+      propertyPath: LandingPoint
+      value: 
+      objectReference: {fileID: 593684685}
+    - target: {fileID: 9213398412280628274, guid: ee35a22c9c046446c9f2e4b25053cb69, type: 3}
       propertyPath: DestinationTeleporter
       value: 
       objectReference: {fileID: 796754678}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 2166065586888593827, guid: ee35a22c9c046446c9f2e4b25053cb69, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ee35a22c9c046446c9f2e4b25053cb69, type: 3}
@@ -24231,3 +24481,4 @@ SceneRoots:
   - {fileID: 878947365}
   - {fileID: 1393638781}
   - {fileID: 2127903491}
+  - {fileID: 2040737504}

--- a/Assets/Scenes/Overworld.unity
+++ b/Assets/Scenes/Overworld.unity
@@ -6497,22 +6497,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 2282598973215270436, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: m_Size.y
-      value: 0.61930746
-      objectReference: {fileID: 0}
-    - target: {fileID: 2282598973215270436, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: m_Offset.y
-      value: 0.31890747
-      objectReference: {fileID: 0}
-    - target: {fileID: 2947611010104209421, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: moveSpeed
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 2947611010104209421, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: shouldRotateOnTurn
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5553036053896267798, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.01
@@ -6552,18 +6536,6 @@ PrefabInstance:
     - target: {fileID: 5553036053896267798, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5957394632817136815, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: Health
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8443585188686732594, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8454525523054177503, guid: e3c3a71caf7954eacb125989ba6b3a1d, type: 3}
-      propertyPath: colorChangeDuration
-      value: 0.248
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Checkpoint.cs
+++ b/Assets/Scripts/Checkpoint.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+public class Checkpoint : MonoBehaviour
+{
+    public LayerMask PlayerLayer;
+
+    // NOTE: This script's game object should have a trigger collider
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (Utils.HasTargetLayer(PlayerLayer, other.gameObject))
+        {
+            Debug.Log("Setting player checkpoint: " + gameObject.name);
+            SetPlayerCheckpoint(other.gameObject);
+        }
+    }
+
+    private void SetPlayerCheckpoint(GameObject player)
+    {
+        PlayerController playerController = player.GetComponent<PlayerController>();
+        playerController.LastCheckpoint = this;
+    }
+
+    // TeleportPlayer sets the player's position to this checkpoint's position
+    public void TeleportPlayer(GameObject player)
+    {
+        Debug.Log("Teleporting player from current position " + player.transform.position + " to checkpoint position " + transform.position);
+        player.transform.position = transform.position;
+    }
+}

--- a/Assets/Scripts/Checkpoint.cs.meta
+++ b/Assets/Scripts/Checkpoint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 385f616da086b4e6d8b0d9313cd6262d

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -45,6 +45,9 @@ public class PlayerController : MonoBehaviour
     public float MaxHealth;
     // Make Health public so it's easily editable in the Inspector
     public float Health;
+    // On death, teleport player to last checkpoint touched
+    public Checkpoint LastCheckpoint;
+
     private PlayerAnimation playerAnimation;
     private PlayerAttack playerAttack;
     private PlayerAudio playerAudio;

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -186,25 +186,41 @@ public class PlayerController : MonoBehaviour
 
     public IEnumerator TakeDamage()
     {
-        Health -= 1;
-
         if (CurrentState == PlayerState.Default)
         {
-            // TODO: implement "stunned" state
-            CurrentState = PlayerState.Stunned;
-            StartCoroutine(playerAttack.DamageColorChangeRoutine());
-            playerAudio.PlayHit();
-            yield return StartCoroutine(playerAttack.AttackCooldown());
-            Debug.Log("Ouch!");
-            CurrentState = PlayerState.Default;
-            Debug.Log($"Player health: {Health}"); 
+            Health -= 1;
+            if (Health > 0)
+            {
+                StartCoroutine(HandleStun());
+            }
+            else
+            {
+                HandleDeath();
+            }
         }
-        // TODO: Implement Player Death
-        // else if (Health <= 0)
-        // {
-        //     // PlayerController.CurrentState = PlayerState.Dead;
-        //     Debug.Log("Dead!");
-        // }
+        return null;
+    }
+
+    private IEnumerator HandleStun()
+    {
+        CurrentState = PlayerState.Stunned;
+        StartCoroutine(playerAttack.DamageColorChangeRoutine());
+        playerAudio.PlayHit();
+        yield return StartCoroutine(playerAttack.AttackCooldown());
+        CurrentState = PlayerState.Default;
+    }
+
+    private void HandleDeath()
+    {
+        CurrentState = PlayerState.Dead;
+        if (LastCheckpoint != null)
+        {
+            // Teleport player to last teleporter touched
+            LastCheckpoint.TeleportPlayer(gameObject);
+        }
+        // Reset health and state
+        Health = MaxHealth;
+        CurrentState = PlayerState.Default;
     }
 
     public void OnAttackFinished()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -42,6 +42,8 @@ public class PlayerController : MonoBehaviour
     public LayerMask DialogueLayer;
     public LayerMask PushableLayer;
 
+    public float MaxHealth;
+    // Make Health public so it's easily editable in the Inspector
     public float Health;
     private PlayerAnimation playerAnimation;
     private PlayerAttack playerAttack;
@@ -70,6 +72,8 @@ public class PlayerController : MonoBehaviour
         // Subscribe to custom events
         CustomEvents.OnDialogueEnd.AddListener(OnDialogueEnd);
         CustomEvents.OnAttackFinished.AddListener(OnAttackFinished);
+        // Set health to max
+        Health = MaxHealth;
     }
 
     void OnDestroy()
@@ -130,7 +134,7 @@ public class PlayerController : MonoBehaviour
         // After playing last note, wait before starting the melody audio
         yield return new WaitForSeconds(AudioData.TimeBeforeMelody);
 
-        // Clears note queue when melody is completed 
+        // Clears note queue when melody is completed
         lastPlayedNotes.Clear();
 
         // Proximity check for objects affectable by melody


### PR DESCRIPTION
Adds checkpoints to the world. When the player collides with a checkpoint, it's saved as the player's "last checkpoint". On death, the player's health is reset to max and they're teleported to the checkpoint.