### PR TITLE
Fixes bug when resetting lastPlayedNotes

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -59,13 +59,8 @@ public class PlayerController : MonoBehaviour
     private string[] Melodies = new string[2]{
         MelodyData.Melody1, MelodyData.Melody2
     };
-    private Queue<string> lastPlayedNotes = new Queue<string>(new string[MelodyData.MelodyLength]{
-        null,
-        null,
-        null,
-        null,
-        null,
-    });
+    // Track the notes played while in Instrument mode
+    private Queue<string> lastPlayedNotes;
 
     void Awake()
     {
@@ -78,6 +73,8 @@ public class PlayerController : MonoBehaviour
         CustomEvents.OnAttackFinished.AddListener(OnAttackFinished);
         // Set health to max
         Health = MaxHealth;
+        // Initialize lastPlayedNotes to a queue of null values
+        lastPlayedNotes = BuildEmptyNotesQueue();
     }
 
     void OnDestroy()
@@ -91,6 +88,16 @@ public class PlayerController : MonoBehaviour
     {
         CurrentState = PlayerState.Default;
         Debug.Log("dialogue completed");
+    }
+
+    private Queue<string> BuildEmptyNotesQueue() {
+        return new Queue<string>(new string[MelodyData.MelodyLength]{
+            null,
+            null,
+            null,
+            null,
+            null,
+        });
     }
 
     private void ToggleInstrument()
@@ -110,7 +117,7 @@ public class PlayerController : MonoBehaviour
             isPlayingLyre = false;
 
             // Clear the note queue when lyre is put away (to prevent accidental triggers)
-            lastPlayedNotes.Clear();
+            lastPlayedNotes = BuildEmptyNotesQueue();
         }
         // Set animation params after determining movement and isPlayingLyre
         playerAnimation.SetAnimationParams(movement, isPlayingLyre);
@@ -393,10 +400,6 @@ public class PlayerController : MonoBehaviour
                 playerAudio.PlayNote(notePressed);
                 // Remove 1st note from queue, and add new note to end of queue,
                 // so that the new 1st note is now the 4th-last note played
-
-                // BUG: if player initiates play, plays notes w/o successfully playing song
-                //    then initiates play again, "InvalidOperationException: Queue Empty" error is logged
-                
                 lastPlayedNotes.Dequeue();
                 lastPlayedNotes.Enqueue(notePressed);
                 // Check if should play Melody


### PR DESCRIPTION
**Description**
Instead of clearing the queue, which causes Dequeue calls to fail and interrupt the function (because there's nothing left to dequeue), we reset the queue to contain all null values. This achieves the desired effect of resetting the queue in between instrument sessions, so that a melody needs to be played in one session.

**Implementation Details**
Instead of clearing the queue, we "reset" it to its original state of containing all null values. While we could just manually set `lastPlayedNotes` to a new `Queue`, like how we did when we initialized the variable, a more DRY (Don't Repeat Yourself) best practice is to encapsulate this logic in a single place, so we create a new function `BuildEmptyNotesQueue`. This allows us to keep the logic for building a queue in one place, which means if we ever want to change it (e.g. change the length of the queue to allow for a different melody length), we only have to change it in one place. Because of how C# works when defining and calling functions, we can't just call the function at the time of initializing `lastPlayedNotes` (I don't know the full specifics, but likely something like the function doesn't exist yet at that part in the code. Don't quote me on that, though!). To accommodate the language rules, we instead just assign a value to `lastPlayedNotes` during the `Awake` function, which ensures that the queue will always be initialized before we try to do anything with it.